### PR TITLE
Add find-many MongoDB processor operation

### DIFF
--- a/internal/impl/mongodb/common.go
+++ b/internal/impl/mongodb/common.go
@@ -116,6 +116,8 @@ const (
 	OperationUpdateOne Operation = "update-one"
 	// OperationFindOne Find one operation.
 	OperationFindOne Operation = "find-one"
+	// OperationFindMany Find many operation.
+	OperationFindMany Operation = "find-many"
 	// OperationInvalid Invalid operation.
 	OperationInvalid Operation = "invalid"
 )
@@ -137,7 +139,8 @@ func (op Operation) isFilterAllowed() bool {
 		OperationDeleteMany,
 		OperationReplaceOne,
 		OperationUpdateOne,
-		OperationFindOne:
+		OperationFindOne,
+		OperationFindMany:
 		return true
 	default:
 		return false
@@ -150,7 +153,8 @@ func (op Operation) isHintAllowed() bool {
 		OperationDeleteMany,
 		OperationReplaceOne,
 		OperationUpdateOne,
-		OperationFindOne:
+		OperationFindOne,
+		OperationFindMany:
 		return true
 	default:
 		return false
@@ -182,6 +186,8 @@ func NewOperation(op string) Operation {
 		return OperationUpdateOne
 	case "find-one":
 		return OperationFindOne
+	case "find-many":
+		return OperationFindMany
 	default:
 		return OperationInvalid
 	}
@@ -194,7 +200,7 @@ const (
 
 func processorOperationDocs(defaultOperation Operation) docs.FieldSpec {
 	fs := outputOperationDocs(defaultOperation)
-	return fs.HasOptions(append(fs.Options, string(OperationFindOne))...)
+	return fs.HasOptions(append(fs.Options, string(OperationFindOne), string(OperationFindMany))...)
 }
 
 func outputOperationDocs(defaultOperation Operation) docs.FieldSpec {

--- a/website/docs/components/processors/mongodb.md
+++ b/website/docs/components/processors/mongodb.md
@@ -132,7 +132,7 @@ The mongodb operation to perform.
 
 Type: `string`  
 Default: `"insert-one"`  
-Options: `insert-one`, `delete-one`, `delete-many`, `replace-one`, `update-one`, `find-one`.
+Options: `insert-one`, `delete-one`, `delete-many`, `replace-one`, `update-one`, `find-one`, `find-many`.
 
 ### `write_concern`
 


### PR DESCRIPTION
# Principais alterações

- Adiciona operação `find-many` no processor `mongodb`

# Como testar?

Execute a configuração abaixo "apontando" para seu banco de dados MongoDB

```yaml
input:
  generate:
    count: 1
    interval: ""
    mapping: 'root = {}'

pipeline:
  processors:
    - mongodb:
        url: mongodb://localhost:27017
        database: "my-database"
        username: "my-username"
        password: "my-password"
        collection: "my-collection"
        operation: find-many
        filter_map: "{}"

output:
  stdout:
    codec: lines
```