### PR TITLE
fix: Change the mssql default string type from nvarchar to varchar

### DIFF
--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/Masterminds/squirrel"
+	mssql "github.com/denisenkom/go-mssqldb"
 
 	"github.com/Jeffail/shutdown"
 
@@ -253,6 +254,13 @@ func (s *sqlInsertOutput) WriteBatch(ctx context.Context, batch service.MessageB
 		}
 
 		if tx == nil {
+			if s.driver == "mssql" {
+				for i, arg := range args {
+					if str, validStr := arg.(string); validStr {
+						args[i] = mssql.VarChar(str)
+					}
+				}
+			}
 			insertBuilder = insertBuilder.Values(args...)
 		} else if _, err := stmt.Exec(args...); err != nil {
 			_ = tx.Rollback()


### PR DESCRIPTION
By default the string type used by the mssql driver in the sql output is nvarchar. From now, the default string value will be the varchar.

https://github.com/microsoft/go-mssqldb?tab=readme-ov-file#parameter-types