### PR TITLE
fix: Disable connect loop if configured

### DIFF
--- a/internal/component/output/async_writer.go
+++ b/internal/component/output/async_writer.go
@@ -212,7 +212,7 @@ func (w *AsyncWriter) loop() {
 			latency, err := w.latencyMeasuringWrite(closeLeisureCtx, ts.Payload)
 
 			// If our writer says it is not connected.
-			if errors.Is(err, component.ErrNotConnected) {
+			if errors.Is(err, component.ErrNotConnected) && !ignoreOutputConnectionErrors() {
 				latency, err = connectLoop(ts.Payload)
 			} else if err != nil {
 				mError.Incr(1)


### PR DESCRIPTION
Related task: Related task: https://curupira.visualstudio.com/BLiP/_boards/board/t/Firehose/Backlog%20items/?workitem=797285

This pull request includes several changes to the `internal/component/output/async_writer.go` file to improve the handling of reconnection logic in the `AsyncWriter` component. The most important changes include adding a new field to track reconnection times, modifying the reconnection logic to respect a timeout, and handling errors more gracefully.

### Enhancements to reconnection logic:

* Added a new field `reconnectedAt` to the `AsyncWriter` struct to track the last reconnection time.
* Initialized the `reconnectedAt` field with the current time in the `NewAsyncWriter` function.
* Updated the error handling in the `loop` method to respect a reconnection timeout and set the `reconnectedAt` time upon reconnection.

### Error handling improvements:

* Modified the error handling in the `loop` method to ignore certain connection errors based on a condition.

### New utility function:

* Added a new `reconnectionTimeout` method to the `AsyncWriter` struct to check if the reconnection timeout has been reached, based on an environment variable `BENTHOS_RECONNECT_TIMEOUT`.